### PR TITLE
Fix message state initialization

### DIFF
--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -10,13 +10,13 @@ import './home.css';
 
 export default function Home(props: {lang: string}) {
 
-    const [messages, setMessages] = useState<[MessageFormProps]>()
+    const [messages, setMessages] = useState<MessageFormProps[]>([])
 
     const user = {
         "uid" : "Guest"
     }
 
-    if (messages === undefined) {
+    if (messages.length === 0) {
         setTimeout(
             FirstReply,
             1750,


### PR DESCRIPTION
## Summary
- initialize chat message state as an array instead of undefined
- trigger the first reply when message list is empty

## Testing
- `yarn test --watchAll=false` *(fails: package doesn't seem to be present in lockfile without running install)*

------
https://chatgpt.com/codex/tasks/task_e_6855158668b083339b58cf56024d47ce