### PR TITLE
Improve chatbox styling

### DIFF
--- a/portfolio/src/App.test.tsx
+++ b/portfolio/src/App.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
-import SkillTree from './components/skilltree/SkillTree';
 
 // Mock the chatbox component to avoid transforming ESM syntax during tests
 jest.mock('react-chatbox-component', () => ({
   ChatBox: () => <div data-testid="chatbox" />,
+}));
+
+// Mock Radar chart to avoid canvas issues when rendering App
+jest.mock('react-chartjs-2', () => ({
+  Radar: () => <div data-testid="radar-chart" />,
 }));
 
 test('renders header text and skill tree', () => {
@@ -12,6 +16,5 @@ test('renders header text and skill tree', () => {
   // Default language is Japanese, so check for the Japanese header text
   const heading = screen.getByText(/樹神 宇徳/i);
   expect(heading).toBeInTheDocument();
-  render(<SkillTree />);
-  expect(screen.getByText(/Frontend/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/Frontend/i).length).toBeGreaterThan(0);
 });

--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -1,6 +1,30 @@
 
+
+body {
+  background-color: #343541;
+  color: #ececf1;
+}
+
 .chatbox {
-  max-width: 600px;
+  max-width: 700px;
   margin: 2rem auto;
+}
+
+/* ChatGPT like styling overrides for react-chatbox-component */
+.chatbox .chat-box {
+  background-color: #444654;
+  border-radius: 8px;
+  padding: 1rem;
+  border: none;
+}
+
+.chatbox .chat-bubble.is-user {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
+.chatbox .chat-bubble.is-other {
+  background-color: #3f3f46;
+  color: #fff;
 }
 

--- a/portfolio/src/components/personality/PersonalityRadar.test.tsx
+++ b/portfolio/src/components/personality/PersonalityRadar.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import PersonalityRadar from './PersonalityRadar';
 
+// Mock the Radar component to avoid canvas issues in jsdom
+jest.mock('react-chartjs-2', () => ({
+  Radar: () => <div data-testid="radar-chart" />,
+}));
+
 test('renders personality radar chart heading', () => {
   render(<PersonalityRadar />);
   expect(screen.getByText('Personality Radar Chart')).toBeInTheDocument();

--- a/portfolio/src/setupTests.ts
+++ b/portfolio/src/setupTests.ts
@@ -3,3 +3,33 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill window.matchMedia used by react-chrono
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// Provide a basic crypto.getRandomValues implementation for libraries that rely on it
+Object.defineProperty(global, 'crypto', {
+  value: {
+    getRandomValues: (arr: any) => require('crypto').randomFillSync(arr),
+  },
+});
+
+// Basic IntersectionObserver mock used by react-chrono
+(global as any).IntersectionObserver = class {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
## Summary
- style chat interface like ChatGPT
- update test setup for React Chrono and Chart.js
- mock Radar chart during tests
- fix App test assertions

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6855702102188333ae6dbef78e737344