### PR TITLE
Change header text

### DIFF
--- a/portfolio/src/App.test.tsx
+++ b/portfolio/src/App.test.tsx
@@ -8,8 +8,8 @@ jest.mock('react-chatbox-component', () => ({
 
 test('renders header text and chatbox', () => {
   render(<App />);
-  // Default language is Japanese, so check for the Japanese header text
-  const heading = screen.getByText(/樹神 宇徳/i);
+  // The header should display the English name by default
+  const heading = screen.getByText(/Takanori Kotama/i);
   expect(heading).toBeInTheDocument();
   // Verify that chatbox placeholder renders
   expect(screen.getByTestId('chatbox')).toBeInTheDocument();

--- a/portfolio/src/components/header/header.tsx
+++ b/portfolio/src/components/header/header.tsx
@@ -19,7 +19,7 @@ export default function Header(props: {lang: string, setLang: (lang: string) => 
             <AppBar position="static">
                 <Toolbar variant="dense">
                     <Typography variant="h6" color="inherit" component="div">
-                        {props.lang === 'en' ? 'Takanori Kotama' : '樹神 宇徳'}
+                        Takanori Kotama
                     </Typography>
                 </Toolbar>
                 <Button onClick={changeLanguage}>


### PR DESCRIPTION
## Summary
- show `Takanori Kotama` always in the header
- adjust test to match new heading

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685570a785fc8333a9e0c193df3458e0