### PR TITLE
Fix chat API fallback and add Firebase rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ yarn start
 
 The site will be available at [http://localhost:3000](http://localhost:3000).
 
+The chat interface relies on a Cloud Function named `selectFunction`. When
+developing locally you can set the `REACT_APP_SELECT_FUNCTION_URL` environment
+variable to the function's URL, but if it is omitted the app will automatically
+call `/selectFunction` which is mapped to the function via Firebase Hosting
+rewrites.
+
 ### Tests
 
 Unit tests can be run from the `portfolio` directory:

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -32,6 +32,11 @@ You can learn more in the [Create React App documentation](https://facebook.gith
 
 The project includes a Cloud Function named `selectFunction` that uses Firebase AI to determine which internal function should handle a user's request. It expects a JSON body with a `text` field and responds with the selected function name.
 
+When running the React app locally, you can set `REACT_APP_SELECT_FUNCTION_URL`
+to the full URL of this function. If the variable is not set, the app falls back
+to calling `/selectFunction`, which works when Firebase Hosting rewrites are
+configured (as in this repository).
+
 Example request using `curl`:
 
 ```bash

--- a/portfolio/firebase.json
+++ b/portfolio/firebase.json
@@ -8,6 +8,10 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "rewrites": [
+      { "source": "/selectFunction", "function": "selectFunction" },
+      { "source": "/autoReply", "function": "autoReply" }
     ]
   }
 }

--- a/portfolio/src/components/home/AiChatBox.tsx
+++ b/portfolio/src/components/home/AiChatBox.tsx
@@ -7,11 +7,10 @@ interface AiMessage {
 }
 
 async function callSelectFunction(text: string): Promise<string | undefined> {
-  const url = process.env.REACT_APP_SELECT_FUNCTION_URL;
-  if (!url) {
-    console.error('REACT_APP_SELECT_FUNCTION_URL not set');
-    return undefined;
-  }
+  // Default to calling the Cloud Function via a relative path when no
+  // environment variable is provided. This allows the app to work even if the
+  // build-time variable is missing (e.g. in preview deployments).
+  const url = process.env.REACT_APP_SELECT_FUNCTION_URL || '/selectFunction';
   try {
     const res = await fetch(url, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- allow chat to call selectFunction using default `/selectFunction` path
- expose cloud functions via Firebase Hosting rewrites
- document new behavior in README files

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68557b0d71d8833385ffc5e71ca2226c