### PR TITLE
Add irregular response helper function

### DIFF
--- a/portfolio/src/utils/irregular.test.ts
+++ b/portfolio/src/utils/irregular.test.ts
@@ -1,0 +1,11 @@
+import { respondToIrregularInput } from './irregular';
+
+test('returns null for regular requests', () => {
+  expect(respondToIrregularInput('Show me your bio')).toBeNull();
+});
+
+test('returns message for irregular requests', () => {
+  expect(respondToIrregularInput('random text')).toBe(
+    'Sorry, I could not understand your request.'
+  );
+});

--- a/portfolio/src/utils/irregular.ts
+++ b/portfolio/src/utils/irregular.ts
@@ -1,0 +1,17 @@
+export function respondToIrregularInput(text: string): string | null {
+  const keywords = [
+    'bio',
+    'skill',
+    'interest',
+    'personality',
+    'contact',
+    'portfolio',
+  ];
+
+  const normalized = text.toLowerCase();
+  const isRegular = keywords.some((kw) => normalized.includes(kw));
+  if (!text.trim() || !isRegular) {
+    return 'Sorry, I could not understand your request.';
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add helper to detect irregular requests and return a fallback text
- test irregular response helper

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68569ffb275c833395c21b64088b21a2