### PR TITLE
Fix chatbox scroll freeze

### DIFF
--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -2,6 +2,8 @@
 .chatbox {
   max-width: 600px;
   margin: 2rem auto;
+  height: 400px;
+  overflow-y: auto;
 }
 
 .msg-user {


### PR DESCRIPTION
## Summary
- prevent layout from shifting while the AI is talking

## Testing
- `yarn test --watchAll=false` *(fails: TypeError: Cannot redefine property: crypto)*

------
https://chatgpt.com/codex/tasks/task_e_6856a58c13748333ae78724e31ab97bf