### PR TITLE
Add global language switch

### DIFF
--- a/portfolio/src/App.tsx
+++ b/portfolio/src/App.tsx
@@ -19,16 +19,17 @@ function App() {
     <>
       <Header
         lang={lang}
-        setLang={setLang} 
+        setLang={setLang}
       />
       <Home
         lang={lang}
+        setLang={setLang}
       />
-      <BioTree />
-      <SkillTree />
-      <InterestGraph />
-      <PersonalityRadar />
-      <OtherSiteLinks />
+      <BioTree lang={lang} setLang={setLang} />
+      <SkillTree lang={lang} setLang={setLang} />
+      <InterestGraph lang={lang} setLang={setLang} />
+      <PersonalityRadar lang={lang} setLang={setLang} />
+      <OtherSiteLinks lang={lang} setLang={setLang} />
     </>
   );
 }

--- a/portfolio/src/components/LanguageSwitch.tsx
+++ b/portfolio/src/components/LanguageSwitch.tsx
@@ -1,0 +1,15 @@
+import Button from '@mui/material/Button';
+
+export interface LangProps {
+  lang: string;
+  setLang: (lang: string) => void;
+}
+
+export default function LanguageSwitch({ lang, setLang }: LangProps) {
+  const toggleLang = () => setLang(lang === 'en' ? 'ja' : 'en');
+  return (
+    <Button color="inherit" onClick={toggleLang}>
+      {lang === 'en' ? '日本語' : 'English'}
+    </Button>
+  );
+}

--- a/portfolio/src/components/bio/BioTree.tsx
+++ b/portfolio/src/components/bio/BioTree.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Chrono } from 'react-chrono';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import items from './bio.json';
 
 export interface BioItem {
@@ -9,9 +10,14 @@ export interface BioItem {
   cardDetailedText?: string;
 }
 
-const BioTree: React.FC = () => {
+const BioTree: React.FC<LangProps> = ({ lang, setLang }) => {
   const data = items as BioItem[];
-  return <Chrono items={data} mode="VERTICAL_ALTERNATING" />;
+  return (
+    <div>
+      <LanguageSwitch lang={lang} setLang={setLang} />
+      <Chrono items={data} mode="VERTICAL_ALTERNATING" />
+    </div>
+  );
 };
 
 export default BioTree;

--- a/portfolio/src/components/header/header.tsx
+++ b/portfolio/src/components/header/header.tsx
@@ -2,22 +2,14 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
+import LanguageSwitch from '../LanguageSwitch';
 
 interface HeaderProps {
     lang: string;
     setLang: (lang: string) => void;
 }
+
 export default function Header(props: HeaderProps){
-
-    const changeLanguage = () => {
-        if (props.lang === 'en') {
-            props.setLang('ja');
-        } else {
-            props.setLang('en');
-        }
-    }    
-
     return (
         <Box sx={{ flexGrow: 1 }}>
             <AppBar position="static">
@@ -25,9 +17,7 @@ export default function Header(props: HeaderProps){
                     <Typography variant="h6" color="inherit" component="div" sx={{ flexGrow: 1 }}>
                         {props.lang === 'en' ? 'Takanori Kotama' : '樹神 宇徳'}
                     </Typography>
-                    <Button color="inherit" onClick={changeLanguage}>
-                        {props.lang === 'en' ? '日本語' : 'English'}
-                    </Button>
+                    <LanguageSwitch lang={props.lang} setLang={props.setLang} />
                 </Toolbar>
             </AppBar>
         </Box>

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import { ChatBox } from 'react-chatbox-component';
 import AiChatBox from './AiChatBox';
 
@@ -9,7 +10,7 @@ import 'react-chatbox-component/dist/style.css';
 import './home.css';
 
 
-export default function Home(props: {lang: string}) {
+export default function Home(props: LangProps) {
 
     const [messages, setMessages] = useState<MessageFormProps[]>([])
 
@@ -30,6 +31,7 @@ export default function Home(props: {lang: string}) {
 
     return (
         <div>
+            <LanguageSwitch lang={props.lang} setLang={props.setLang} />
             <div className='chatbox'>
                 <ChatBox
                     messages={messages}

--- a/portfolio/src/components/interests/InterestGraph.test.tsx
+++ b/portfolio/src/components/interests/InterestGraph.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import InterestGraph from './InterestGraph';
 
 test('renders interest graph items', () => {
-  render(<InterestGraph />);
+  render(<InterestGraph lang="en" setLang={() => {}} />);
   expect(screen.getByText('Technology')).toBeInTheDocument();
   expect(screen.getByText('Artificial Intelligence')).toBeInTheDocument();
 });

--- a/portfolio/src/components/interests/InterestGraph.tsx
+++ b/portfolio/src/components/interests/InterestGraph.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import interests from './interests.json';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface InterestItem {
   title: string;
@@ -19,9 +20,14 @@ export const createInterestGraph = (data: InterestItem[]): JSX.Element => {
   );
 };
 
-const InterestGraph: React.FC = () => {
+const InterestGraph: React.FC<LangProps> = ({ lang, setLang }) => {
   const data = interests as InterestItem[];
-  return <div>{createInterestGraph(data)}</div>;
+  return (
+    <div>
+      <LanguageSwitch lang={lang} setLang={setLang} />
+      {createInterestGraph(data)}
+    </div>
+  );
 };
 
 export default InterestGraph;

--- a/portfolio/src/components/links/OtherSiteLinks.test.tsx
+++ b/portfolio/src/components/links/OtherSiteLinks.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import OtherSiteLinks from './OtherSiteLinks';
 
 test('renders other site links', () => {
-  render(<OtherSiteLinks />);
+  render(<OtherSiteLinks lang="en" setLang={() => {}} />);
   expect(screen.getByText('GitHub')).toBeInTheDocument();
   expect(screen.getByText('X')).toBeInTheDocument();
   expect(screen.getByText('Qiita')).toBeInTheDocument();

--- a/portfolio/src/components/links/OtherSiteLinks.tsx
+++ b/portfolio/src/components/links/OtherSiteLinks.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface SiteLink {
   name: string;
@@ -11,8 +12,9 @@ const links: SiteLink[] = [
   { name: 'Qiita', url: 'https://qiita.com/kotama7' }
 ];
 
-const OtherSiteLinks: React.FC = () => (
+const OtherSiteLinks: React.FC<LangProps> = ({ lang, setLang }) => (
   <div>
+    <LanguageSwitch lang={lang} setLang={setLang} />
     <h3>Other Sites</h3>
     <ul>
       {links.map(link => (

--- a/portfolio/src/components/personality/PersonalityRadar.test.tsx
+++ b/portfolio/src/components/personality/PersonalityRadar.test.tsx
@@ -8,6 +8,6 @@ beforeAll(() => {
 });
 
 test('renders personality radar chart heading', () => {
-  render(<PersonalityRadar />);
+  render(<PersonalityRadar lang="en" setLang={() => {}} />);
   expect(screen.getByText('Personality Radar Chart')).toBeInTheDocument();
 });

--- a/portfolio/src/components/personality/PersonalityRadar.tsx
+++ b/portfolio/src/components/personality/PersonalityRadar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import { Radar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -18,7 +19,7 @@ export interface PersonalityData {
   values: number[];
 }
 
-const PersonalityRadar: React.FC = () => {
+const PersonalityRadar: React.FC<LangProps> = ({ lang, setLang }) => {
   const personality = data as PersonalityData;
   const chartData = {
     labels: personality.labels,
@@ -35,6 +36,7 @@ const PersonalityRadar: React.FC = () => {
 
   return (
     <div>
+      <LanguageSwitch lang={lang} setLang={setLang} />
       <h3>Personality Radar Chart</h3>
       <Radar data={chartData} />
     </div>

--- a/portfolio/src/components/qualification/QualificationList.test.tsx
+++ b/portfolio/src/components/qualification/QualificationList.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import QualificationList from './QualificationList';
 
 test('renders qualifications', () => {
-  render(<QualificationList />);
+  render(<QualificationList lang="en" setLang={() => {}} />);
   expect(screen.getByText(/Nagoya University/)).toBeInTheDocument();
   expect(screen.getByText(/AI App Development/)).toBeInTheDocument();
 });

--- a/portfolio/src/components/qualification/QualificationList.tsx
+++ b/portfolio/src/components/qualification/QualificationList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import qualifications from './qualifications.json';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface QualificationItem {
   title: string;
@@ -21,9 +22,14 @@ export const createQualificationList = (data: QualificationItem[]): JSX.Element 
   );
 };
 
-const QualificationList: React.FC = () => {
+const QualificationList: React.FC<LangProps> = ({ lang, setLang }) => {
   const data = qualifications as QualificationItem[];
-  return <div>{createQualificationList(data)}</div>;
+  return (
+    <div>
+      <LanguageSwitch lang={lang} setLang={setLang} />
+      {createQualificationList(data)}
+    </div>
+  );
 };
 
 export default QualificationList;

--- a/portfolio/src/components/skills/SkillTree.test.tsx
+++ b/portfolio/src/components/skills/SkillTree.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import SkillTree from './SkillTree';
 
 test('renders skill tree items', () => {
-  render(<SkillTree />);
+  render(<SkillTree lang="en" setLang={() => {}} />);
   expect(screen.getByText('Frontend')).toBeInTheDocument();
   expect(screen.getByText('React')).toBeInTheDocument();
   expect(screen.getByText('Backend')).toBeInTheDocument();

--- a/portfolio/src/components/skills/SkillTree.tsx
+++ b/portfolio/src/components/skills/SkillTree.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import skills from './skills.json';
+import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface SkillItem {
   title: string;
@@ -19,9 +20,14 @@ export const createSkillTree = (data: SkillItem[]): JSX.Element => {
   );
 };
 
-const SkillTree: React.FC = () => {
+const SkillTree: React.FC<LangProps> = ({ lang, setLang }) => {
   const data = skills as SkillItem[];
-  return <div>{createSkillTree(data)}</div>;
+  return (
+    <div>
+      <LanguageSwitch lang={lang} setLang={setLang} />
+      {createSkillTree(data)}
+    </div>
+  );
 };
 
 export default SkillTree;


### PR DESCRIPTION
## Summary
- create a reusable `LanguageSwitch` component
- show the switch in header, home and all other sections
- pass `lang` and `setLang` through `App`
- adjust tests for new props

## Testing
- `CI=true npm test --silent` *(fails: TypeError: Cannot redefine property: crypto)*

------
https://chatgpt.com/codex/tasks/task_e_6856a4e99f6483339242d2cab0d27499