### PR TITLE
Fix language switch

### DIFF
--- a/portfolio/src/App.test.tsx
+++ b/portfolio/src/App.test.tsx
@@ -7,11 +7,13 @@ jest.mock('react-chatbox-component', () => ({
 }));
 
 beforeAll(() => {
-  Object.defineProperty(globalThis, 'crypto', {
-    value: {
-      getRandomValues: (arr: Uint8Array) => require('crypto').randomFillSync(arr)
-    }
-  });
+  if (!globalThis.crypto) {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        getRandomValues: (arr: Uint8Array) => require('crypto').randomFillSync(arr)
+      }
+    });
+  }
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: jest.fn().mockImplementation((query) => ({

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import { ChatBox } from 'react-chatbox-component';
 import AiChatBox from './AiChatBox';
@@ -18,16 +18,18 @@ export default function Home(props: LangProps) {
         "uid" : "Guest"
     }
 
-    if (messages.length === 0) {
-        setTimeout(
-            FirstReply,
-            1750,
-            {
-                seter: setMessages, 
-                lang: props.lang
-            }
-        )
-    }
+    useEffect(() => {
+        if (messages.length === 0) {
+            const timer = setTimeout(() =>
+                FirstReply({
+                    seter: setMessages,
+                    lang: props.lang
+                }),
+                1750
+            );
+            return () => clearTimeout(timer);
+        }
+    }, [messages.length, props.lang]);
 
     return (
         <div>


### PR DESCRIPTION
## Summary
- update test setup to skip redefining global crypto if it already exists
- ensure the first chat message respects the selected language

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6856a94ae29c8333a354bdfffb46a964