### PR TITLE
Improve function selection fallback

### DIFF
--- a/portfolio/functions/index.js
+++ b/portfolio/functions/index.js
@@ -34,7 +34,25 @@ exports.selectFunction = functions.https.onRequest(async (req, res) => {
     res.json({ function: functionName });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to select function' });
+    const normalized = text.toLowerCase();
+    const fallbackMap = [
+      { keyword: 'bio', func: 'bioGraph' },
+      { keyword: 'skill', func: 'skillTree' },
+      { keyword: 'interest', func: 'interestGraph' },
+      { keyword: 'personality', func: 'personalityRadar' },
+      { keyword: 'contact', func: 'contactInfo' },
+      { keyword: 'portfolio', func: 'portfolioSummary' },
+      { keyword: 'link', func: 'otherSiteLinks' },
+      { keyword: 'external', func: 'otherSiteLinks' },
+    ];
+    const matched = fallbackMap.find(({ keyword }) =>
+      normalized.includes(keyword)
+    );
+    if (matched) {
+      res.json({ function: matched.func, fallback: true });
+    } else {
+      res.status(500).json({ error: 'Failed to select function' });
+    }
   }
 });
 

--- a/portfolio/src/utils/irregular.ts
+++ b/portfolio/src/utils/irregular.ts
@@ -6,6 +6,8 @@ export function respondToIrregularInput(text: string): string | null {
     'personality',
     'contact',
     'portfolio',
+    'link',
+    'external',
   ];
 
   const normalized = text.toLowerCase();


### PR DESCRIPTION
## Summary
- add keyword-based fallback mapping to `selectFunction`
- expand irregular input detection with more keywords

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6856e1d7eaa88333ae7e18a1314c1bb8