### PR TITLE
Remove duplicate language switch

### DIFF
--- a/portfolio/src/App.tsx
+++ b/portfolio/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
   return (
     <>
       <Header lang={lang} setLang={setLang} />
-      <Home lang={lang} setLang={setLang} />
+      <Home lang={lang} />
     </>
   );
 }

--- a/portfolio/src/components/bio/BioTree.tsx
+++ b/portfolio/src/components/bio/BioTree.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Chrono } from 'react-chrono';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import items from './bio.json';
 
 export interface BioItem {
@@ -10,14 +9,9 @@ export interface BioItem {
   cardDetailedText?: string;
 }
 
-const BioTree: React.FC<LangProps> = ({ lang, setLang }) => {
+const BioTree: React.FC = () => {
   const data = items as BioItem[];
-  return (
-    <div>
-      <LanguageSwitch lang={lang} setLang={setLang} />
-      <Chrono items={data} mode="VERTICAL_ALTERNATING" />
-    </div>
-  );
+  return <Chrono items={data} mode="VERTICAL_ALTERNATING" />;
 };
 
 export default BioTree;

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import { ChatBox } from 'react-chatbox-component';
 
 import 'react-chatbox-component/dist/style.css';
@@ -25,7 +24,7 @@ async function callSelectFunction(text: string): Promise<string | undefined> {
 }
 
 
-export default function Home(props: LangProps) {
+export default function Home(props: { lang: string }) {
 
     const [messages, setMessages] = useState<MessageFormProps[]>([])
 
@@ -76,7 +75,6 @@ export default function Home(props: LangProps) {
 
     return (
         <div>
-            <LanguageSwitch lang={props.lang} setLang={props.setLang} />
             <div className='chatbox'>
                 <ChatBox
                     messages={messages}

--- a/portfolio/src/components/interests/InterestGraph.test.tsx
+++ b/portfolio/src/components/interests/InterestGraph.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import InterestGraph from './InterestGraph';
 
 test('renders interest graph items', () => {
-  render(<InterestGraph lang="en" setLang={() => {}} />);
+  render(<InterestGraph />);
   expect(screen.getByText('Technology')).toBeInTheDocument();
   expect(screen.getByText('Artificial Intelligence')).toBeInTheDocument();
 });

--- a/portfolio/src/components/interests/InterestGraph.tsx
+++ b/portfolio/src/components/interests/InterestGraph.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import interests from './interests.json';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface InterestItem {
   title: string;
@@ -20,14 +19,9 @@ export const createInterestGraph = (data: InterestItem[]): JSX.Element => {
   );
 };
 
-const InterestGraph: React.FC<LangProps> = ({ lang, setLang }) => {
+const InterestGraph: React.FC = () => {
   const data = interests as InterestItem[];
-  return (
-    <div>
-      <LanguageSwitch lang={lang} setLang={setLang} />
-      {createInterestGraph(data)}
-    </div>
-  );
+  return <>{createInterestGraph(data)}</>;
 };
 
 export default InterestGraph;

--- a/portfolio/src/components/links/OtherSiteLinks.test.tsx
+++ b/portfolio/src/components/links/OtherSiteLinks.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import OtherSiteLinks from './OtherSiteLinks';
 
 test('renders other site links', () => {
-  render(<OtherSiteLinks lang="en" setLang={() => {}} />);
+  render(<OtherSiteLinks />);
   expect(screen.getByText('GitHub')).toBeInTheDocument();
   expect(screen.getByText('X')).toBeInTheDocument();
   expect(screen.getByText('Qiita')).toBeInTheDocument();

--- a/portfolio/src/components/links/OtherSiteLinks.tsx
+++ b/portfolio/src/components/links/OtherSiteLinks.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface SiteLink {
   name: string;
@@ -12,9 +11,8 @@ const links: SiteLink[] = [
   { name: 'Qiita', url: 'https://qiita.com/kotama7' }
 ];
 
-const OtherSiteLinks: React.FC<LangProps> = ({ lang, setLang }) => (
+const OtherSiteLinks: React.FC = () => (
   <div>
-    <LanguageSwitch lang={lang} setLang={setLang} />
     <h3>Other Sites</h3>
     <ul>
       {links.map(link => (

--- a/portfolio/src/components/personality/PersonalityRadar.test.tsx
+++ b/portfolio/src/components/personality/PersonalityRadar.test.tsx
@@ -8,6 +8,6 @@ beforeAll(() => {
 });
 
 test('renders personality radar chart heading', () => {
-  render(<PersonalityRadar lang="en" setLang={() => {}} />);
+  render(<PersonalityRadar />);
   expect(screen.getByText('Personality Radar Chart')).toBeInTheDocument();
 });

--- a/portfolio/src/components/personality/PersonalityRadar.tsx
+++ b/portfolio/src/components/personality/PersonalityRadar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 import { Radar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -19,7 +18,7 @@ export interface PersonalityData {
   values: number[];
 }
 
-const PersonalityRadar: React.FC<LangProps> = ({ lang, setLang }) => {
+const PersonalityRadar: React.FC = () => {
   const personality = data as PersonalityData;
   const chartData = {
     labels: personality.labels,
@@ -36,7 +35,6 @@ const PersonalityRadar: React.FC<LangProps> = ({ lang, setLang }) => {
 
   return (
     <div>
-      <LanguageSwitch lang={lang} setLang={setLang} />
       <h3>Personality Radar Chart</h3>
       <Radar data={chartData} />
     </div>

--- a/portfolio/src/components/qualification/QualificationList.test.tsx
+++ b/portfolio/src/components/qualification/QualificationList.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import QualificationList from './QualificationList';
 
 test('renders qualifications', () => {
-  render(<QualificationList lang="en" setLang={() => {}} />);
+  render(<QualificationList />);
   expect(screen.getByText(/Nagoya University/)).toBeInTheDocument();
   expect(screen.getByText(/AI App Development/)).toBeInTheDocument();
 });

--- a/portfolio/src/components/qualification/QualificationList.tsx
+++ b/portfolio/src/components/qualification/QualificationList.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import qualifications from './qualifications.json';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface QualificationItem {
   title: string;
@@ -22,14 +21,9 @@ export const createQualificationList = (data: QualificationItem[]): JSX.Element 
   );
 };
 
-const QualificationList: React.FC<LangProps> = ({ lang, setLang }) => {
+const QualificationList: React.FC = () => {
   const data = qualifications as QualificationItem[];
-  return (
-    <div>
-      <LanguageSwitch lang={lang} setLang={setLang} />
-      {createQualificationList(data)}
-    </div>
-  );
+  return <>{createQualificationList(data)}</>;
 };
 
 export default QualificationList;

--- a/portfolio/src/components/skills/SkillTree.test.tsx
+++ b/portfolio/src/components/skills/SkillTree.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import SkillTree from './SkillTree';
 
 test('renders skill tree items', () => {
-  render(<SkillTree lang="en" setLang={() => {}} />);
+  render(<SkillTree />);
   expect(screen.getByText('Frontend')).toBeInTheDocument();
   expect(screen.getByText('React')).toBeInTheDocument();
   expect(screen.getByText('Backend')).toBeInTheDocument();

--- a/portfolio/src/components/skills/SkillTree.tsx
+++ b/portfolio/src/components/skills/SkillTree.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import skills from './skills.json';
-import LanguageSwitch, { LangProps } from '../LanguageSwitch';
 
 export interface SkillItem {
   title: string;
@@ -20,14 +19,9 @@ export const createSkillTree = (data: SkillItem[]): JSX.Element => {
   );
 };
 
-const SkillTree: React.FC<LangProps> = ({ lang, setLang }) => {
+const SkillTree: React.FC = () => {
   const data = skills as SkillItem[];
-  return (
-    <div>
-      <LanguageSwitch lang={lang} setLang={setLang} />
-      {createSkillTree(data)}
-    </div>
-  );
+  return <>{createSkillTree(data)}</>;
 };
 
 export default SkillTree;


### PR DESCRIPTION
## Summary
- keep language switch only in the header
- drop lang/setLang props from feature components
- update tests accordingly

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba39015888333aee84fdfb7fa87c1