### PR TITLE
Fix selectFunction call error handling

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -35,7 +35,9 @@ The project includes a Cloud Function named `selectFunction` that uses Firebase 
 When running the React app locally, you can set `REACT_APP_SELECT_FUNCTION_URL`
 to the full URL of this function. If the variable is not set, the app falls back
 to calling `/selectFunction`, which works when Firebase Hosting rewrites are
-configured (as in this repository).
+configured (as in this repository). Running without this variable while using
+`yarn start` will cause the development server to return HTML, leading to a JSON
+parse error in the browser.
 
 Example request using `curl`:
 

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -15,6 +15,16 @@ async function callSelectFunction(text: string): Promise<string | undefined> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text })
     });
+
+    if (!res.ok) {
+      throw new Error(`HTTP error ${res.status}`);
+    }
+
+    const contentType = res.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      throw new Error('Response is not JSON');
+    }
+
     const data = await res.json();
     return data.function as string;
   } catch (err) {


### PR DESCRIPTION
## Summary
- improve error handling in `callSelectFunction` to catch non-JSON responses
- document that missing `REACT_APP_SELECT_FUNCTION_URL` causes a JSON parse error

## Testing
- `yarn test --watchAll=false` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_685ba9248c608333a372ee05bb23b1fc