### PR TITLE
Add sidebar with callable functions

### DIFF
--- a/portfolio/src/components/home/FunctionSidebar.test.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.test.tsx
@@ -8,3 +8,9 @@ test('calls onSelect with function name', () => {
   fireEvent.click(button);
   expect(handler).toHaveBeenCalledWith('bioGraph');
 });
+
+test('highlights selected function', () => {
+  render(<FunctionSidebar onSelect={() => {}} selected="skillTree" />);
+  const activeBtn = screen.getByText('skillTree');
+  expect(activeBtn.className).toMatch(/active/);
+});

--- a/portfolio/src/components/home/FunctionSidebar.test.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import FunctionSidebar from './FunctionSidebar';
+
+test('calls onSelect with function name', () => {
+  const handler = jest.fn();
+  render(<FunctionSidebar onSelect={handler} />);
+  const button = screen.getByText('bioGraph');
+  fireEvent.click(button);
+  expect(handler).toHaveBeenCalledWith('bioGraph');
+});

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 export interface FunctionSidebarProps {
   onSelect: (name: string) => void;
+  selected?: string | null;
 }
 
 const functions = [
@@ -14,13 +15,18 @@ const functions = [
   'otherSiteLinks',
 ];
 
-const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect }) => (
+const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected }) => (
   <div className="sidebar">
     <h3>Functions</h3>
     <ul>
       {functions.map((name) => (
         <li key={name}>
-          <button onClick={() => onSelect(name)}>{name}</button>
+          <button
+            className={`sidebar-button ${selected === name ? 'active' : ''}`}
+            onClick={() => onSelect(name)}
+          >
+            {name}
+          </button>
         </li>
       ))}
     </ul>

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface FunctionSidebarProps {
+  onSelect: (name: string) => void;
+}
+
+const functions = [
+  'bioGraph',
+  'skillTree',
+  'interestGraph',
+  'personalityRadar',
+  'contactInfo',
+  'portfolioSummary',
+  'otherSiteLinks',
+];
+
+const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect }) => (
+  <div className="sidebar">
+    <h3>Functions</h3>
+    <ul>
+      {functions.map((name) => (
+        <li key={name}>
+          <button onClick={() => onSelect(name)}>{name}</button>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default FunctionSidebar;

--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -17,3 +17,17 @@
 }
 
 
+
+.home-container {
+  display: flex;
+}
+
+.sidebar {
+  width: 200px;
+  padding: 1rem;
+  border-right: 1px solid #ccc;
+}
+
+.chat-container {
+  flex: 1;
+}

--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -20,14 +20,56 @@
 
 .home-container {
   display: flex;
+  height: 100vh;
 }
 
 .sidebar {
-  width: 200px;
+  width: 240px;
   padding: 1rem;
-  border-right: 1px solid #ccc;
+  background-color: #202123;
+  color: #ececf1;
+  border-right: 1px solid #343541;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar h3 {
+  margin-top: 0;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.sidebar-button {
+  width: 100%;
+  background: #343541;
+  border: none;
+  border-radius: 6px;
+  color: #ececf1;
+  padding: 0.5rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sidebar-button:hover {
+  background: #40414f;
+}
+
+.sidebar-button.active {
+  background: #2b2c2f;
 }
 
 .chat-container {
   flex: 1;
+  background: #ffffff;
 }

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -6,6 +6,12 @@ import './home.css';
 
 import MessageFormProps from './module/message_form';
 import FirstReply from './module/first_reply';
+import FunctionSidebar from './FunctionSidebar';
+import BioTree from '../bio/BioTree';
+import SkillTree from '../skills/SkillTree';
+import InterestGraph from '../interests/InterestGraph';
+import PersonalityRadar from '../personality/PersonalityRadar';
+import OtherSiteLinks from '../links/OtherSiteLinks';
 
 async function callSelectFunction(text: string): Promise<string | undefined> {
   const url = process.env.REACT_APP_SELECT_FUNCTION_URL || '/selectFunction';
@@ -27,6 +33,7 @@ async function callSelectFunction(text: string): Promise<string | undefined> {
 export default function Home(props: { lang: string }) {
 
     const [messages, setMessages] = useState<MessageFormProps[]>([])
+    const [selectedFunc, setSelectedFunc] = useState<string | null>(null)
 
     const user = {
         "uid" : "Guest"
@@ -60,6 +67,27 @@ export default function Home(props: { lang: string }) {
         setMessages(prev => [...prev, botMsg]);
     }
 
+    const renderFunction = () => {
+        switch (selectedFunc) {
+            case 'bioGraph':
+                return <BioTree />;
+            case 'skillTree':
+                return <SkillTree />;
+            case 'interestGraph':
+                return <InterestGraph />;
+            case 'personalityRadar':
+                return <PersonalityRadar />;
+            case 'otherSiteLinks':
+                return <OtherSiteLinks />;
+            case 'contactInfo':
+                return <div>Contact: example@example.com</div>;
+            case 'portfolioSummary':
+                return <div>This portfolio showcases my work with React and TypeScript.</div>;
+            default:
+                return null;
+        }
+    };
+
     useEffect(() => {
         if (messages.length === 0) {
             const timer = setTimeout(() =>
@@ -74,13 +102,17 @@ export default function Home(props: { lang: string }) {
     }, [messages.length, props.lang]);
 
     return (
-        <div>
-            <div className='chatbox'>
-                <ChatBox
-                    messages={messages}
-                    user={user}
-                    onSubmit={handleSendMessage}
-                />
+        <div className='home-container'>
+            <FunctionSidebar onSelect={setSelectedFunc} />
+            <div className='chat-container'>
+                <div className='chatbox'>
+                    <ChatBox
+                        messages={messages}
+                        user={user}
+                        onSubmit={handleSendMessage}
+                    />
+                </div>
+                {renderFunction()}
             </div>
         </div>
     );

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -103,7 +103,7 @@ export default function Home(props: { lang: string }) {
 
     return (
         <div className='home-container'>
-            <FunctionSidebar onSelect={setSelectedFunc} />
+            <FunctionSidebar onSelect={setSelectedFunc} selected={selectedFunc} />
             <div className='chat-container'>
                 <div className='chatbox'>
                     <ChatBox


### PR DESCRIPTION
## Summary
- add `FunctionSidebar` component for quick function selection
- embed sidebar and selected function display in `Home`
- style new sidebar layout
- test sidebar behavior

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685ba9ee3e5c83338373dba2b8a4e73c