### PR TITLE
Add sidebar toggle

### DIFF
--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 export interface FunctionSidebarProps {
   onSelect: (name: string) => void;
   selected?: string | null;
+  onClose?: () => void;
 }
 
 const functions = [
@@ -15,8 +16,13 @@ const functions = [
   'otherSiteLinks',
 ];
 
-const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected }) => (
+const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected, onClose }) => (
   <div className="sidebar">
+    {onClose && (
+      <button className="sidebar-close" onClick={onClose} aria-label="close sidebar">
+        ×
+      </button>
+    )}
     <h3>Functions</h3>
     <ul>
       {functions.map((name) => (

--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -21,6 +21,7 @@
 .home-container {
   display: flex;
   height: 100vh;
+  position: relative;
 }
 
 .sidebar {
@@ -72,4 +73,27 @@
 .chat-container {
   flex: 1;
   background: #ffffff;
+}
+
+.sidebar-close {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  color: #ececf1;
+  font-size: 1.2rem;
+  cursor: pointer;
+  margin-bottom: 0.5rem;
+}
+
+.sidebar-open {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  background: #343541;
+  border: none;
+  border-radius: 6px;
+  color: #ececf1;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  z-index: 1000;
 }

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -44,6 +44,7 @@ export default function Home(props: { lang: string }) {
 
     const [messages, setMessages] = useState<MessageFormProps[]>([])
     const [selectedFunc, setSelectedFunc] = useState<string | null>(null)
+    const [sidebarOpen, setSidebarOpen] = useState<boolean>(true)
 
     const user = {
         "uid" : "Guest"
@@ -113,7 +114,15 @@ export default function Home(props: { lang: string }) {
 
     return (
         <div className='home-container'>
-            <FunctionSidebar onSelect={setSelectedFunc} selected={selectedFunc} />
+            {sidebarOpen ? (
+                <FunctionSidebar
+                    onSelect={setSelectedFunc}
+                    selected={selectedFunc}
+                    onClose={() => setSidebarOpen(false)}
+                />
+            ) : (
+                <button className='sidebar-open' onClick={() => setSidebarOpen(true)}>Open</button>
+            )}
             <div className='chat-container'>
                 <div className='chatbox'>
                     <ChatBox


### PR DESCRIPTION
## Summary
- add optional `onClose` prop to sidebar component
- implement open and close buttons for sidebar
- style sidebar toggle buttons

## Testing
- `yarn test --watchAll=false` *(fails: package missing because dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bb83cce5083338bcd21166431d38b