### PR TITLE
Add language-aware bot responses

### DIFF
--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -65,7 +65,13 @@ export default function Home(props: { lang: string }) {
         setMessages(prev => [...prev, userMsg]);
 
         const func = await callSelectFunction(input);
-        const botText = func ? `Function selected: ${func}` : 'Failed to get response';
+        const botText = func
+            ? (props.lang === 'en'
+                ? `Function selected: ${func}`
+                : `選択された機能: ${func}`)
+            : props.lang === 'en'
+                ? 'Failed to get response'
+                : '返答を取得できませんでした';
         const botMsg: MessageFormProps = {
             text: botText,
             id: userMsg.id + 1,
@@ -111,6 +117,12 @@ export default function Home(props: { lang: string }) {
             return () => clearTimeout(timer);
         }
     }, [messages.length, props.lang]);
+
+    // Reset conversation when language changes
+    useEffect(() => {
+        setMessages([]);
+        setSelectedFunc(null);
+    }, [props.lang]);
 
     return (
         <div className='home-container'>


### PR DESCRIPTION
## Summary
- reset chat when switching languages so first AI message uses new language
- localize bot replies in chat for selected language

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685bc2b6c1d8833398cd398344b18eb9