### PR TITLE
Implement new chat reset

### DIFF
--- a/portfolio/src/components/home/FunctionSidebar.test.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.test.tsx
@@ -9,6 +9,14 @@ test('calls onSelect with function name', () => {
   expect(handler).toHaveBeenCalledWith('bioGraph');
 });
 
+test('includes newChat button', () => {
+  const handler = jest.fn();
+  render(<FunctionSidebar onSelect={handler} />);
+  const newChatBtn = screen.getByText('newChat');
+  fireEvent.click(newChatBtn);
+  expect(handler).toHaveBeenCalledWith('newChat');
+});
+
 test('highlights selected function', () => {
   render(<FunctionSidebar onSelect={() => {}} selected="skillTree" />);
   const activeBtn = screen.getByText('skillTree');

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -7,6 +7,7 @@ export interface FunctionSidebarProps {
 }
 
 const functions = [
+  'newChat',
   'bioGraph',
   'skillTree',
   'interestGraph',

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -84,6 +84,15 @@ export default function Home(props: { lang: string }) {
         setMessages(prev => [...prev, botMsg]);
     }
 
+    const handleSidebarSelect = (name: string) => {
+        if (name === 'newChat') {
+            setMessages([]);
+            setSelectedFunc(null);
+        } else {
+            setSelectedFunc(name);
+        }
+    }
+
     const renderFunction = () => {
         switch (selectedFunc) {
             case 'bioGraph':
@@ -128,7 +137,7 @@ export default function Home(props: { lang: string }) {
         <div className='home-container'>
             {sidebarOpen ? (
                 <FunctionSidebar
-                    onSelect={setSelectedFunc}
+                    onSelect={handleSidebarSelect}
                     selected={selectedFunc}
                     onClose={() => setSidebarOpen(false)}
                 />


### PR DESCRIPTION
## Summary
- add `newChat` action to the sidebar
- reset message history when `newChat` is selected
- test for newChat button

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685bcaccc87083339a9b6460d174ebcd