### PR TITLE
Add language-aware labels for sidebar and chat

### DIFF
--- a/portfolio/src/App.tsx
+++ b/portfolio/src/App.tsx
@@ -8,7 +8,7 @@ import './App.css';
 
 function App() {
 
-  const [lang, setLang] = useState<string>('ja');
+  const [lang, setLang] = useState<'en' | 'ja'>('ja');
 
   return (
     <>

--- a/portfolio/src/components/LanguageSwitch.tsx
+++ b/portfolio/src/components/LanguageSwitch.tsx
@@ -1,8 +1,8 @@
 import Button from '@mui/material/Button';
 
 export interface LangProps {
-  lang: string;
-  setLang: (lang: string) => void;
+  lang: 'en' | 'ja';
+  setLang: (lang: 'en' | 'ja') => void;
 }
 
 export default function LanguageSwitch({ lang, setLang }: LangProps) {

--- a/portfolio/src/components/header/header.tsx
+++ b/portfolio/src/components/header/header.tsx
@@ -5,8 +5,8 @@ import Box from '@mui/material/Box';
 import LanguageSwitch from '../LanguageSwitch';
 
 interface HeaderProps {
-    lang: string;
-    setLang: (lang: string) => void;
+    lang: 'en' | 'ja';
+    setLang: (lang: 'en' | 'ja') => void;
 }
 
 export default function Header(props: HeaderProps){

--- a/portfolio/src/components/home/FunctionSidebar.test.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.test.tsx
@@ -3,7 +3,7 @@ import FunctionSidebar from './FunctionSidebar';
 
 test('calls onSelect with function name', () => {
   const handler = jest.fn();
-  render(<FunctionSidebar onSelect={handler} />);
+  render(<FunctionSidebar onSelect={handler} lang="en" />);
   const button = screen.getByText('Please explain your biography');
   fireEvent.click(button);
   expect(handler).toHaveBeenCalledWith('bioGraph');
@@ -11,14 +11,14 @@ test('calls onSelect with function name', () => {
 
 test('includes newChat button', () => {
   const handler = jest.fn();
-  render(<FunctionSidebar onSelect={handler} />);
-  const newChatBtn = screen.getByText('newChat');
+  render(<FunctionSidebar onSelect={handler} lang="ja" />);
+  const newChatBtn = screen.getByText('新しいチャット');
   fireEvent.click(newChatBtn);
   expect(handler).toHaveBeenCalledWith('newChat');
 });
 
 test('highlights selected function', () => {
-  render(<FunctionSidebar onSelect={() => {}} selected="skillTree" />);
+  render(<FunctionSidebar onSelect={() => {}} selected="skillTree" lang="en" />);
   const activeBtn = screen.getByText('Show me your skills');
   expect(activeBtn.className).toMatch(/active/);
 });

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -4,7 +4,7 @@ export interface FunctionSidebarProps {
   onSelect: (name: string) => void;
   selected?: string | null;
   onClose?: () => void;
-  lang: string;
+  lang: 'en' | 'ja';
 }
 
 interface FunctionItem {

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -4,24 +4,38 @@ export interface FunctionSidebarProps {
   onSelect: (name: string) => void;
   selected?: string | null;
   onClose?: () => void;
+  lang: string;
 }
 
 interface FunctionItem {
   id: string;
-  label: string;
 }
 
 const functions: FunctionItem[] = [
-  { id: 'bioGraph', label: 'Please explain your biography' },
-  { id: 'skillTree', label: 'Show me your skills' },
-  { id: 'interestGraph', label: 'What are your interests?' },
-  { id: 'personalityRadar', label: 'Show your personality traits' },
-  { id: 'contactInfo', label: 'Provide your contact info' },
-  { id: 'portfolioSummary', label: 'Summarize your portfolio' },
-  { id: 'otherSiteLinks', label: 'Share other site links' },
+  { id: 'bioGraph' },
+  { id: 'skillTree' },
+  { id: 'interestGraph' },
+  { id: 'personalityRadar' },
+  { id: 'contactInfo' },
+  { id: 'portfolioSummary' },
+  { id: 'otherSiteLinks' },
 ];
 
-const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected, onClose }) => (
+const labels: Record<string, { en: string; ja: string }> = {
+  bioGraph: { en: 'Please explain your biography', ja: '経歴を教えてください' },
+  skillTree: { en: 'Show me your skills', ja: 'スキルを見せてください' },
+  interestGraph: { en: 'What are your interests?', ja: '興味を教えてください' },
+  personalityRadar: {
+    en: 'Show your personality traits',
+    ja: '性格の特徴を見せてください',
+  },
+  contactInfo: { en: 'Provide your contact info', ja: '連絡先を教えてください' },
+  portfolioSummary: { en: 'Summarize your portfolio', ja: 'ポートフォリオを要約してください' },
+  otherSiteLinks: { en: 'Share other site links', ja: 'その他のリンクを教えてください' },
+  newChat: { en: 'newChat', ja: '新しいチャット' },
+};
+
+const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected, onClose, lang }) => (
   <div className="sidebar">
     {onClose && (
       <button className="sidebar-close" onClick={onClose} aria-label="close sidebar">
@@ -30,13 +44,18 @@ const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected, o
     )}
     <h3>Sample Chat</h3>
     <ul>
-      {functions.map(({ id, label }) => (
+      <li key="newChat">
+        <button className="sidebar-button" onClick={() => onSelect('newChat')}>
+          {labels.newChat[lang]}
+        </button>
+      </li>
+      {functions.map(({ id }) => (
         <li key={id}>
           <button
             className={`sidebar-button ${selected === id ? 'active' : ''}`}
             onClick={() => onSelect(id)}
           >
-            {label}
+            {labels[id][lang]}
           </button>
         </li>
       ))}

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -15,6 +15,16 @@ import InterestGraph from '../interests/InterestGraph';
 import PersonalityRadar from '../personality/PersonalityRadar';
 import OtherSiteLinks from '../links/OtherSiteLinks';
 
+const FUNC_NAMES: Record<string, { en: string; ja: string }> = {
+  bioGraph: { en: 'Biography', ja: '経歴' },
+  skillTree: { en: 'Skills', ja: 'スキル' },
+  interestGraph: { en: 'Interests', ja: '興味' },
+  personalityRadar: { en: 'Personality', ja: '性格' },
+  contactInfo: { en: 'Contact Info', ja: '連絡先' },
+  portfolioSummary: { en: 'Portfolio Summary', ja: 'ポートフォリオ概要' },
+  otherSiteLinks: { en: 'Other Site Links', ja: 'その他のリンク' },
+};
+
 let model: ReturnType<typeof getGenerativeModel> | null = null;
 
 function getModel() {
@@ -74,8 +84,8 @@ export default function Home(props: { lang: string }) {
         const func = await callSelectFunction(input);
         const botText = func
             ? (props.lang === 'en'
-                ? `Function selected: ${func}`
-                : `選択された機能: ${func}`)
+                ? `Function selected: ${FUNC_NAMES[func]?.en ?? func}`
+                : `選択された機能: ${FUNC_NAMES[func]?.ja ?? func}`)
             : props.lang === 'en'
                 ? 'Failed to get response'
                 : '返答を取得できませんでした';
@@ -113,9 +123,21 @@ export default function Home(props: { lang: string }) {
             case 'otherSiteLinks':
                 return <OtherSiteLinks />;
             case 'contactInfo':
-                return <div>Contact: example@example.com</div>;
+                return (
+                    <div>
+                        {props.lang === 'en'
+                            ? 'Contact: example@example.com'
+                            : '連絡先: example@example.com'}
+                    </div>
+                );
             case 'portfolioSummary':
-                return <div>This portfolio showcases my work with React and TypeScript.</div>;
+                return (
+                    <div>
+                        {props.lang === 'en'
+                            ? 'This portfolio showcases my work with React and TypeScript.'
+                            : 'このポートフォリオでは React と TypeScript を用いた成果を紹介しています。'}
+                    </div>
+                );
             default:
                 return null;
         }
@@ -147,6 +169,7 @@ export default function Home(props: { lang: string }) {
                     onSelect={handleSidebarSelect}
                     selected={selectedFunc}
                     onClose={() => setSidebarOpen(false)}
+                    lang={props.lang}
                 />
             ) : (
                 <button className='sidebar-open' onClick={() => setSidebarOpen(true)}>Open</button>

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -57,7 +57,7 @@ async function callSelectFunction(text: string): Promise<string | undefined> {
 }
 
 
-export default function Home(props: { lang: string }) {
+export default function Home(props: { lang: 'en' | 'ja' }) {
 
     const [messages, setMessages] = useState<MessageFormProps[]>([])
     const [selectedFunc, setSelectedFunc] = useState<string | null>(null)

--- a/portfolio/src/components/home/module/first_reply.tsx
+++ b/portfolio/src/components/home/module/first_reply.tsx
@@ -5,7 +5,7 @@ import { default_second_message_ja, default_second_message_en } from "./data"
 
 interface FirstReplyProps {
     seter: Function;
-    lang: string;
+    lang: 'en' | 'ja';
 }
 
 export default function FirstReply(props: FirstReplyProps) {


### PR DESCRIPTION
## Summary
- support language-aware function labels in `FunctionSidebar`
- translate bot messages and sidebar to selected language
- update tests for new `lang` prop

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685bdd4fe6448333b37d90bb7587f893