### PR TITLE
Add fallback for AI selection

### DIFF
--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -14,6 +14,7 @@ import SkillTree from '../skills/SkillTree';
 import InterestGraph from '../interests/InterestGraph';
 import PersonalityRadar from '../personality/PersonalityRadar';
 import OtherSiteLinks from '../links/OtherSiteLinks';
+import { fallbackSelectFunction } from '../../utils/selectFunction';
 
 const FUNC_NAMES: Record<string, { en: string; ja: string }> = {
   bioGraph: { en: 'Biography', ja: '経歴' },
@@ -52,21 +53,7 @@ async function callSelectFunction(text: string): Promise<string | undefined> {
     return result.response.text().trim();
   } catch (err) {
     console.error('Failed to call selectFunction', err);
-    const normalized = text.toLowerCase();
-    const fallbackMap = [
-      { keyword: 'bio', func: 'bioGraph' },
-      { keyword: 'skill', func: 'skillTree' },
-      { keyword: 'interest', func: 'interestGraph' },
-      { keyword: 'personality', func: 'personalityRadar' },
-      { keyword: 'contact', func: 'contactInfo' },
-      { keyword: 'portfolio', func: 'portfolioSummary' },
-      { keyword: 'link', func: 'otherSiteLinks' },
-      { keyword: 'external', func: 'otherSiteLinks' },
-    ];
-    const matched = fallbackMap.find(({ keyword }) =>
-      normalized.includes(keyword)
-    );
-    return matched?.func;
+    return fallbackSelectFunction(text);
   }
 }
 

--- a/portfolio/src/utils/selectFunction.test.ts
+++ b/portfolio/src/utils/selectFunction.test.ts
@@ -1,0 +1,11 @@
+import { fallbackSelectFunction } from './selectFunction';
+
+test('matches keywords to function names', () => {
+  expect(fallbackSelectFunction('show me your bio')).toBe('bioGraph');
+  expect(fallbackSelectFunction('Tell me your skills')).toBe('skillTree');
+});
+
+test('returns undefined when no keywords match', () => {
+  expect(fallbackSelectFunction('nonsense input')).toBeUndefined();
+});
+

--- a/portfolio/src/utils/selectFunction.ts
+++ b/portfolio/src/utils/selectFunction.ts
@@ -1,0 +1,21 @@
+export const FALLBACK_KEYWORDS = [
+  { keyword: 'bio', func: 'bioGraph' },
+  { keyword: 'skill', func: 'skillTree' },
+  { keyword: 'interest', func: 'interestGraph' },
+  { keyword: 'personality', func: 'personalityRadar' },
+  { keyword: 'contact', func: 'contactInfo' },
+  { keyword: 'portfolio', func: 'portfolioSummary' },
+  { keyword: 'link', func: 'otherSiteLinks' },
+  { keyword: 'external', func: 'otherSiteLinks' },
+] as const;
+
+export type FunctionName = typeof FALLBACK_KEYWORDS[number]['func'];
+
+export function fallbackSelectFunction(text: string): FunctionName | undefined {
+  const normalized = text.toLowerCase();
+  const found = FALLBACK_KEYWORDS.find(({ keyword }) =>
+    normalized.includes(keyword)
+  );
+  return found?.func;
+}
+


### PR DESCRIPTION
## Summary
- add keyword fallback logic when AI service isn't available
- ensure tests pass

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685e84b673c4833387bf32065061f385