### PR TITLE
Add chat input lock during bot replies

### DIFF
--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -1,9 +1,20 @@
 
+.chatbox-wrapper {
+  position: relative;
+}
+
 .chatbox {
   max-width: 600px;
   margin: 2rem auto;
   height: 400px;
   overflow-y: auto;
+}
+
+.chatbox-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 10;
 }
 
 .msg-user {

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -63,6 +63,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
     const [selectedFunc, setSelectedFunc] = useState<string | null>(null)
     const [sidebarOpen, setSidebarOpen] = useState<boolean>(true)
     const [autoFirstReply, setAutoFirstReply] = useState<boolean>(true)
+    const [isReplying, setIsReplying] = useState<boolean>(false)
 
     const user = {
         "uid" : "Guest"
@@ -82,6 +83,8 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
         };
         setMessages(prev => [...prev, userMsg]);
 
+        setIsReplying(true);
+
         const func = await callSelectFunction(input);
         const botText = func
             ? (props.lang === 'en'
@@ -100,6 +103,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
             }
         };
         setMessages(prev => [...prev, botMsg]);
+        setIsReplying(false);
     }
 
     const handleSidebarSelect = (name: string) => {
@@ -107,6 +111,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
             setMessages([]);
             setSelectedFunc(null);
             setAutoFirstReply(false);
+            setIsReplying(false);
         } else {
             setSelectedFunc(name);
         }
@@ -150,7 +155,9 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
             const timer = setTimeout(() => {
                     FirstReply({
                         seter: setMessages,
-                        lang: props.lang
+                        lang: props.lang,
+                        onStart: () => setIsReplying(true),
+                        onEnd: () => setIsReplying(false),
                     });
                     setAutoFirstReply(false);
                 },
@@ -165,6 +172,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
         setMessages([]);
         setSelectedFunc(null);
         setAutoFirstReply(true);
+        setIsReplying(false);
     }, [props.lang]);
 
     return (
@@ -180,12 +188,15 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
                 <button className='sidebar-open' onClick={() => setSidebarOpen(true)}>Open</button>
             )}
             <div className='chat-container'>
-                <div className='chatbox'>
-                    <ChatBox
-                        messages={messages}
-                        user={user}
-                        onSubmit={handleSendMessage}
-                    />
+                <div className='chatbox-wrapper'>
+                    <div className='chatbox'>
+                        <ChatBox
+                            messages={messages}
+                            user={user}
+                            onSubmit={handleSendMessage}
+                        />
+                    </div>
+                    {isReplying && <div className='chatbox-overlay'></div>}
                 </div>
                 {renderFunction()}
             </div>

--- a/portfolio/src/components/home/module/first_reply.tsx
+++ b/portfolio/src/components/home/module/first_reply.tsx
@@ -6,6 +6,8 @@ import { default_second_message_ja, default_second_message_en } from "./data"
 interface FirstReplyProps {
     seter: Function;
     lang: 'en' | 'ja';
+    onStart?: () => void;
+    onEnd?: () => void;
 }
 
 export default function FirstReply(props: FirstReplyProps) {
@@ -40,6 +42,8 @@ export default function FirstReply(props: FirstReplyProps) {
         seter: props.seter,
         messages: first_messages,
         next_message: next_message,
+        onStart: props.onStart,
+        onEnd: props.onEnd,
     })
 }
 

--- a/portfolio/src/components/home/module/return_respond.tsx
+++ b/portfolio/src/components/home/module/return_respond.tsx
@@ -5,10 +5,12 @@ interface ReplyProps {
     seter: Function;
     messages: MessageFormProps[];
     next_message: string;
+    onStart?: () => void;
+    onEnd?: () => void;
 }
 
 export default function Reply(props: ReplyProps) {
-    const { seter, messages, next_message } = props;
+    const { seter, messages, next_message, onStart, onEnd } = props;
 
     const append_message_base: MessageFormProps = {
         text: "",
@@ -39,11 +41,13 @@ export default function Reply(props: ReplyProps) {
             const newMessage = { ...append_message_base, text: append_message_text };
             current_messages[current_messages.length - 1] = newMessage;
             seter([...current_messages]);
+            onEnd && onEnd();
         }
     };
 
     current_messages.push(append_message_base);
     seter([...current_messages]);
+    onStart && onStart();
     message_adder();
 }
 


### PR DESCRIPTION
## Summary
- lock the chatbox when Gemini is typing so users can't type
- update first reply and return respond helpers with callbacks for locking
- style overlay for disabled state

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685e8749ded88333b2fcf4f4831e9955