### PR TITLE
Speed up chat bot response

### DIFF
--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -162,7 +162,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
                     });
                     setAutoFirstReply(false);
                 },
-                1750
+                1000
             );
             return () => clearTimeout(timer);
         }

--- a/portfolio/src/components/home/module/return_respond.tsx
+++ b/portfolio/src/components/home/module/return_respond.tsx
@@ -36,7 +36,7 @@ export default function Reply(props: ReplyProps) {
             current_messages[current_messages.length - 1] = newMessage;
             seter([...current_messages]);
             i += 1;
-            setTimeout(message_adder, 50);
+            setTimeout(message_adder, 25);
         } else {
             const newMessage = { ...append_message_base, text: append_message_text };
             current_messages[current_messages.length - 1] = newMessage;


### PR DESCRIPTION
## Summary
- make the first auto reply faster
- make per-character typing delay shorter

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685e8d6e55348333b306d329f9e445e3