### PR TITLE
Remove extra content below chatbox

### DIFF
--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -225,7 +225,6 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
         }
     };
 
-    const renderFunction = () => getFunctionComponent(selectedFunc);
 
     useEffect(() => {
         if (autoFirstReply && messages.length === 0) {
@@ -276,7 +275,6 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
                     </div>
                     {isReplying && <div className='chatbox-overlay'></div>}
                 </div>
-                {renderFunction()}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- stop rendering auxiliary function components below the chat

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685fb295594c833398634e6d4b760ef6