### PR TITLE
Enable Japanese queries for AI

### DIFF
--- a/portfolio/functions/index.js
+++ b/portfolio/functions/index.js
@@ -23,7 +23,13 @@ exports.selectFunction = functions.https.onRequest(async (req, res) => {
     return;
   }
 
-  const prompt = `You are a helpful assistant that maps user requests to function names.\nPossible functions include:\n- bioGraph: returns the biography graph.\n- skillTree: returns the skill hierarchy.\n- interestGraph: returns an interest graph.\n- personalityRadar: shows a personality radar chart.\n- contactInfo: returns contact information.\n- portfolioSummary: gives a summary of the portfolio.\nRespond with only the function name that best matches the user's request.`;
+  const lang = (req.body.lang || 'en').toLowerCase();
+  const basePrompt =
+    'Possible functions include:\n- bioGraph: returns the biography graph.\n- skillTree: returns the skill hierarchy.\n- interestGraph: returns an interest graph.\n- personalityRadar: shows a personality radar chart.\n- contactInfo: returns contact information.\n- portfolioSummary: gives a summary of the portfolio.\nRespond with only the function name that best matches the user\'s request.';
+  const prompt =
+    lang === 'ja'
+      ? `あなたはユーザーのリクエストを関数名に対応付けるアシスタントです。\n${basePrompt}`
+      : `You are a helpful assistant that maps user requests to function names.\n${basePrompt}`;
 
   try {
     const result = await model.generateContent({
@@ -37,12 +43,19 @@ exports.selectFunction = functions.https.onRequest(async (req, res) => {
     const normalized = text.toLowerCase();
     const fallbackMap = [
       { keyword: 'bio', func: 'bioGraph' },
+      { keyword: '経歴', func: 'bioGraph' },
       { keyword: 'skill', func: 'skillTree' },
+      { keyword: 'スキル', func: 'skillTree' },
       { keyword: 'interest', func: 'interestGraph' },
+      { keyword: '興味', func: 'interestGraph' },
       { keyword: 'personality', func: 'personalityRadar' },
+      { keyword: '性格', func: 'personalityRadar' },
       { keyword: 'contact', func: 'contactInfo' },
+      { keyword: '連絡', func: 'contactInfo' },
       { keyword: 'portfolio', func: 'portfolioSummary' },
+      { keyword: 'ポートフォリオ', func: 'portfolioSummary' },
       { keyword: 'link', func: 'otherSiteLinks' },
+      { keyword: 'リンク', func: 'otherSiteLinks' },
       { keyword: 'external', func: 'otherSiteLinks' },
     ];
     const matched = fallbackMap.find(({ keyword }) =>

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -74,8 +74,16 @@ function getModel() {
   return model;
 }
 
-async function callSelectFunction(text: string): Promise<string | undefined> {
-  const prompt = `You are a helpful assistant that maps user requests to function names.\nPossible functions include:\n- bioGraph: returns the biography graph.\n- skillTree: returns the skill hierarchy.\n- interestGraph: returns an interest graph.\n- personalityRadar: shows a personality radar chart.\n- contactInfo: returns contact information.\n- portfolioSummary: gives a summary of the portfolio.\nRespond with only the function name that best matches the user's request.`;
+async function callSelectFunction(
+  text: string,
+  lang: 'en' | 'ja'
+): Promise<string | undefined> {
+  const basePrompt =
+    'Possible functions include:\n- bioGraph: returns the biography graph.\n- skillTree: returns the skill hierarchy.\n- interestGraph: returns an interest graph.\n- personalityRadar: shows a personality radar chart.\n- contactInfo: returns contact information.\n- portfolioSummary: gives a summary of the portfolio.\nRespond with only the function name that best matches the user\'s request.';
+  const prompt =
+    lang === 'ja'
+      ? `あなたはユーザーのリクエストを関数名に対応付けるアシスタントです。\n${basePrompt}`
+      : `You are a helpful assistant that maps user requests to function names.\n${basePrompt}`;
   try {
     const result = await getModel().generateContent({
       contents: [{ role: 'user', parts: [{ text: `${prompt}\n${text}` }] }],
@@ -144,7 +152,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
 
         setIsReplying(true);
 
-        const func = await callSelectFunction(input);
+        const func = await callSelectFunction(input, props.lang);
         const botText = func
             ? FUNC_MESSAGES[func]?.[props.lang] ??
               (props.lang === 'en'

--- a/portfolio/src/utils/selectFunction.test.ts
+++ b/portfolio/src/utils/selectFunction.test.ts
@@ -3,6 +3,8 @@ import { fallbackSelectFunction } from './selectFunction';
 test('matches keywords to function names', () => {
   expect(fallbackSelectFunction('show me your bio')).toBe('bioGraph');
   expect(fallbackSelectFunction('Tell me your skills')).toBe('skillTree');
+  expect(fallbackSelectFunction('経歴を見せて')).toBe('bioGraph');
+  expect(fallbackSelectFunction('スキルを教えて')).toBe('skillTree');
 });
 
 test('returns undefined when no keywords match', () => {

--- a/portfolio/src/utils/selectFunction.ts
+++ b/portfolio/src/utils/selectFunction.ts
@@ -1,11 +1,18 @@
 export const FALLBACK_KEYWORDS = [
   { keyword: 'bio', func: 'bioGraph' },
+  { keyword: '経歴', func: 'bioGraph' },
   { keyword: 'skill', func: 'skillTree' },
+  { keyword: 'スキル', func: 'skillTree' },
   { keyword: 'interest', func: 'interestGraph' },
+  { keyword: '興味', func: 'interestGraph' },
   { keyword: 'personality', func: 'personalityRadar' },
+  { keyword: '性格', func: 'personalityRadar' },
   { keyword: 'contact', func: 'contactInfo' },
+  { keyword: '連絡', func: 'contactInfo' },
   { keyword: 'portfolio', func: 'portfolioSummary' },
+  { keyword: 'ポートフォリオ', func: 'portfolioSummary' },
   { keyword: 'link', func: 'otherSiteLinks' },
+  { keyword: 'リンク', func: 'otherSiteLinks' },
   { keyword: 'external', func: 'otherSiteLinks' },
 ] as const;
 


### PR DESCRIPTION
## Summary
- add Japanese keywords for fallback function selection
- update prompt handling to support Japanese in webapp and Cloud Function
- test fallback function with Japanese

## Testing
- `yarn install`
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68613cc8fae883339b3511732454e223