### PR TITLE
Fix sidebar actions to add chat messages

### DIFF
--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -21,7 +21,7 @@ const functions: FunctionItem[] = [
   { id: 'otherSiteLinks' },
 ];
 
-const labels: Record<string, { en: string; ja: string }> = {
+export const labels: Record<string, { en: string; ja: string }> = {
   bioGraph: { en: 'Please explain your biography', ja: '経歴を教えてください' },
   skillTree: { en: 'Show me your skills', ja: 'スキルを見せてください' },
   interestGraph: { en: 'What are your interests?', ja: '興味を教えてください' },

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -8,7 +8,7 @@ import './home.css';
 
 import MessageFormProps from './module/message_form';
 import FirstReply from './module/first_reply';
-import FunctionSidebar from './FunctionSidebar';
+import FunctionSidebar, { labels } from './FunctionSidebar';
 import BioTree from '../bio/BioTree';
 import SkillTree from '../skills/SkillTree';
 import InterestGraph from '../interests/InterestGraph';
@@ -196,7 +196,34 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
             setAutoFirstReply(false);
             setIsReplying(false);
         } else {
+            const baseId = messages.length + 1;
+            const userMsg: MessageFormProps = {
+                text: labels[name][props.lang],
+                id: baseId,
+                sender: {
+                    uid: 'Guest',
+                    name: 'Guest',
+                    avatar: 'https://www.w3schools.com/howto/img_avatar.png',
+                },
+            };
+            const botMsg: MessageFormProps = {
+                text: FUNC_MESSAGES[name][props.lang],
+                id: baseId + 1,
+                sender: {
+                    uid: 'Takanori Kotama',
+                    name: 'Takanori Kotama',
+                    avatar: `${process.env.PUBLIC_URL}/kotama_icon.jpg`,
+                },
+            };
+            const elementMsg: MessageFormProps = {
+                text: '',
+                id: baseId + 2,
+                sender: botMsg.sender,
+                element: getFunctionComponent(name),
+            };
+            setMessages(prev => [...prev, userMsg, botMsg, elementMsg]);
             setSelectedFunc(name);
+            setAutoFirstReply(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- export sidebar labels
- treat sidebar click as chat message with auto reply

## Testing
- `CI=true yarn test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68614693768c8333836d61628cf1c34f