### PR TITLE
Add briefIntro cloud function

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ award, qualifications and laboratory affiliation when called with a `query` fiel
 It is available at `/profileInfo` after deployment and is also included in the list
 of callable functions used by the AI.
 
+The `briefIntro` function provides a short self-introduction. POST a JSON body
+with a `lang` field (`en` or `ja`) to `/briefIntro` to receive the message in
+the specified language.
+

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -67,3 +67,18 @@ curl -X POST https://<your-region>-<your-project>.cloudfunctions.net/autoReply \
 ```
 
 This will return a JSON response containing the introduction text.
+
+### `briefIntro` function
+
+Returns a short self-introduction message. Send a JSON body with a `lang`
+field (`en` or `ja`) to get the message in that language.
+
+Example:
+
+```bash
+curl -X POST https://<your-region>-<your-project>.cloudfunctions.net/briefIntro \
+     -H "Content-Type: application/json" \
+     -d '{"lang": "en"}'
+```
+
+This will return a JSON response containing the brief self-introduction.

--- a/portfolio/functions/index.js
+++ b/portfolio/functions/index.js
@@ -68,6 +68,8 @@ exports.selectFunction = functions.https.onRequest(async (req, res) => {
       { keyword: 'external', func: 'otherSiteLinks' },
       { keyword: 'profile', func: 'profileInfo' },
       { keyword: 'プロフィール', func: 'profileInfo' },
+      { keyword: 'intro', func: 'briefIntro' },
+      { keyword: '自己紹介', func: 'briefIntro' },
     ];
     const matched = fallbackMap.find(({ keyword }) =>
       normalized.includes(keyword)
@@ -137,4 +139,23 @@ exports.profileInfo = functions.https.onRequest((req, res) => {
   } else {
     res.status(400).json({ error: 'Unknown query' });
   }
+});
+
+// Return a brief self-introduction
+exports.briefIntro = functions.https.onRequest((req, res) => {
+  const intros = {
+    ja: [
+      '名古屋大学コンピュータ科学科4年の小玉貴教です。AIと音楽処理が得意です。',
+      '小玉貴教と申します。名古屋大学でAIを研究し、音楽も好きです。'
+    ],
+    en: [
+      'I\'m Takanori Kotama, a fourth-year CS student at Nagoya University focused on AI and music processing.',
+      'Takanori Kotama here – a student researcher in AI who also enjoys music.'
+    ]
+  };
+
+  const lang = (req.body.lang || 'en').toLowerCase();
+  const candidates = intros[lang] || intros.en;
+  const message = candidates[Math.floor(Math.random() * candidates.length)];
+  res.json({ message });
 });


### PR DESCRIPTION
## Summary
- add new `briefIntro` cloud function for a short self-introduction
- document the new function in both READMEs
- map `intro` keywords in `selectFunction`

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6863b95ed108833399b0e3d4236647b6