### PR TITLE
Expand chat box height initially

### DIFF
--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -113,3 +113,11 @@
   cursor: pointer;
   z-index: 1000;
 }
+/* Expand chatbox to occupy available height */
+.chat-box {
+  height: 100% !important;
+}
+
+.msg-page {
+  height: calc(100% - 60px) !important;
+}


### PR DESCRIPTION
## Summary
- override chat component styles so that the chatbox fills the available space

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6863b999f57c8333b58388c7b6f3669e