### PR TITLE
Implement otherSiteLinks endpoint

### DIFF
--- a/portfolio/functions/index.js
+++ b/portfolio/functions/index.js
@@ -168,3 +168,13 @@ exports.briefIntro = functions.https.onRequest((req, res) => {
   const message = candidates[Math.floor(Math.random() * candidates.length)];
   res.json({ message });
 });
+
+// Return external links to other profiles
+exports.otherSiteLinks = functions.https.onRequest((req, res) => {
+  res.json({
+    github: 'https://github.com/kotama7',
+    qiita: 'https://qiita.com/kotama7',
+    x: 'https://x.com/kotama8',
+    linkedin: 'https://www.linkedin.com/in/takanori-kotama-b785b52a4/'
+  });
+});

--- a/portfolio/src/components/links/OtherSiteLinks.test.tsx
+++ b/portfolio/src/components/links/OtherSiteLinks.test.tsx
@@ -6,4 +6,5 @@ test('renders other site links', () => {
   expect(screen.getByText('GitHub')).toBeInTheDocument();
   expect(screen.getByText('X')).toBeInTheDocument();
   expect(screen.getByText('Qiita')).toBeInTheDocument();
+  expect(screen.getByText('LinkedIn')).toBeInTheDocument();
 });

--- a/portfolio/src/components/links/OtherSiteLinks.tsx
+++ b/portfolio/src/components/links/OtherSiteLinks.tsx
@@ -7,8 +7,9 @@ export interface SiteLink {
 
 const links: SiteLink[] = [
   { name: 'GitHub', url: 'https://github.com/kotama7' },
-  { name: 'X', url: 'https://x.com/kotama7' },
-  { name: 'Qiita', url: 'https://qiita.com/kotama7' }
+  { name: 'Qiita', url: 'https://qiita.com/kotama7' },
+  { name: 'X', url: 'https://x.com/kotama8' },
+  { name: 'LinkedIn', url: 'https://www.linkedin.com/in/takanori-kotama-b785b52a4/' }
 ];
 
 const OtherSiteLinks: React.FC = () => (


### PR DESCRIPTION
## Summary
- add `otherSiteLinks` cloud function with social links
- update `OtherSiteLinks` component to include LinkedIn and fix X link
- adjust tests for new link

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687cabd4ab188333a149d61c8c8964e3