### PR TITLE
Update AI function matching

### DIFF
--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -20,6 +20,9 @@ const functions: FunctionItem[] = [
   { id: 'portfolioSummary' },
   { id: 'otherSiteLinks' },
   { id: 'profileInfo' },
+  { id: 'briefIntro' },
+  { id: 'thesisSummary' },
+  { id: 'fusepThesisSummary' },
 ];
 
 export const labels: Record<string, { en: string; ja: string }> = {
@@ -34,6 +37,9 @@ export const labels: Record<string, { en: string; ja: string }> = {
   portfolioSummary: { en: 'Summarize your portfolio', ja: 'ポートフォリオを要約してください' },
   otherSiteLinks: { en: 'Share other site links', ja: 'その他のリンクを教えてください' },
   profileInfo: { en: 'Profile summary and awards', ja: '概要と受賞など' },
+  briefIntro: { en: 'Give me a brief intro', ja: '自己紹介をお願いします' },
+  thesisSummary: { en: 'Show thesis summary', ja: '論文要約を見せて' },
+  fusepThesisSummary: { en: 'Show FuSEP thesis', ja: '夏研論文を教えて' },
   newChat: { en: 'newChat', ja: '新しいチャット' },
 };
 

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -26,6 +26,9 @@ const FUNC_NAMES: Record<string, { en: string; ja: string }> = {
   portfolioSummary: { en: 'Portfolio Summary', ja: 'ポートフォリオ概要' },
   otherSiteLinks: { en: 'Other Site Links', ja: 'その他のリンク' },
   profileInfo: { en: 'Profile Info', ja: 'プロフィール情報' },
+  briefIntro: { en: 'Brief Intro', ja: '自己紹介' },
+  thesisSummary: { en: 'Thesis Summary', ja: '論文要約' },
+  fusepThesisSummary: { en: 'FuSEP Thesis Summary', ja: '夏研論文要約' },
 };
 
 const FUNC_MESSAGES: Record<string, { en: string; ja: string }> = {
@@ -61,6 +64,18 @@ const FUNC_MESSAGES: Record<string, { en: string; ja: string }> = {
     en: 'Here is my life summary, awards and lab info.',
     ja: '概要や受賞、所属研究室の情報です。',
   },
+  briefIntro: {
+    en: 'Here is a short self introduction.',
+    ja: '簡単な自己紹介です。',
+  },
+  thesisSummary: {
+    en: 'This is the Encouragement Award thesis summary.',
+    ja: '奨励賞論文の要約です。',
+  },
+  fusepThesisSummary: {
+    en: 'This is the FuSEP thesis summary.',
+    ja: '夏研論文の要約です。',
+  },
 };
 
 let model: ReturnType<typeof getGenerativeModel> | null = null;
@@ -94,6 +109,9 @@ async function callSelectFunction(
     '- portfolioSummary: gives a summary of the portfolio.\n' +
     '- otherSiteLinks: returns links to other sites.\n' +
     '- profileInfo: returns life summary, award, qualifications and lab info.\n' +
+    '- briefIntro: returns a short self introduction.\n' +
+    '- thesisSummary: returns the Encouragement Award thesis summary.\n' +
+    '- fusepThesisSummary: returns the FuSEP thesis summary.\n' +
     'Respond with only the function name that best matches the user\'s request.';
   const prompt =
     lang === 'ja'
@@ -280,6 +298,30 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
                         {props.lang === 'en'
                             ? 'Takanori Kotama is a fourth-year CS student in Nagoya University\'s Information Systems program. He received the 2024 Student Paper Contest Encouragement Award and expects to graduate in March 2026.'
                             : '名古屋大学情報学部情報システム専攻の4年生です。2024年の学生論文コンテストで奨励賞を受賞し、2026年3月に学士取得予定です。'}
+                    </div>
+                );
+            case 'briefIntro':
+                return (
+                    <div>
+                        {props.lang === 'en'
+                            ? 'I am Takanori Kotama, a CS student at Nagoya University.'
+                            : '名古屋大学情報学部の樹神宇徳です。'}
+                    </div>
+                );
+            case 'thesisSummary':
+                return (
+                    <div>
+                        {props.lang === 'en'
+                            ? 'Summary of the Encouragement Award thesis.'
+                            : '奨励賞論文の要約です。'}
+                    </div>
+                );
+            case 'fusepThesisSummary':
+                return (
+                    <div>
+                        {props.lang === 'en'
+                            ? 'Summary of the FuSEP thesis.'
+                            : '夏研論文の要約です。'}
                     </div>
                 );
             default:

--- a/portfolio/src/utils/selectFunction.test.ts
+++ b/portfolio/src/utils/selectFunction.test.ts
@@ -6,6 +6,9 @@ test('matches keywords to function names', () => {
   expect(fallbackSelectFunction('経歴を見せて')).toBe('bioGraph');
   expect(fallbackSelectFunction('スキルを教えて')).toBe('skillTree');
   expect(fallbackSelectFunction('profile')).toBe('profileInfo');
+  expect(fallbackSelectFunction('intro')).toBe('briefIntro');
+  expect(fallbackSelectFunction('thesis')).toBe('thesisSummary');
+  expect(fallbackSelectFunction('fusep')).toBe('fusepThesisSummary');
 });
 
 test('returns undefined when no keywords match', () => {

--- a/portfolio/src/utils/selectFunction.ts
+++ b/portfolio/src/utils/selectFunction.ts
@@ -16,6 +16,12 @@ export const FALLBACK_KEYWORDS = [
   { keyword: 'external', func: 'otherSiteLinks' },
   { keyword: 'profile', func: 'profileInfo' },
   { keyword: 'プロフィール', func: 'profileInfo' },
+  { keyword: 'intro', func: 'briefIntro' },
+  { keyword: '自己紹介', func: 'briefIntro' },
+  { keyword: 'thesis', func: 'thesisSummary' },
+  { keyword: '論文要約', func: 'thesisSummary' },
+  { keyword: 'fusep', func: 'fusepThesisSummary' },
+  { keyword: '夏研', func: 'fusepThesisSummary' },
 ] as const;
 
 export type FunctionName = typeof FALLBACK_KEYWORDS[number]['func'];


### PR DESCRIPTION
## Summary
- extend fallback keywords and update AI prompt
- add new function handlers in home component
- expose new functions in sidebar menu
- extend unit tests for keyword fallback

## Testing
- `CI=true yarn --cwd portfolio test`

------
https://chatgpt.com/codex/tasks/task_e_687cb6fc8dc48333ba1067cbdf9cef49