### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -113,3 +113,30 @@
   cursor: pointer;
   z-index: 1000;
 }
+
+@media (max-width: 600px) {
+  .home-container {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 80%;
+    max-width: 300px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1001;
+  }
+
+  .sidebar-opened .sidebar {
+    transform: translateX(0);
+  }
+
+  .chat-container {
+    height: calc(100vh - 48px);
+  }
+}

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -356,7 +356,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
     }, [props.lang]);
 
     return (
-        <div className='home-container'>
+        <div className={`home-container${sidebarOpen ? ' sidebar-opened' : ''}`}>
             {sidebarOpen ? (
                 <FunctionSidebar
                     onSelect={handleSidebarSelect}


### PR DESCRIPTION
## Summary
- tweak `home.tsx` to add a class when sidebar is open
- add media query in `home.css` so the chat interface fits on narrow screens

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687de2ac6a808333ae4d849d9be1463e