### PR TITLE
Trim sidebar menu

### DIFF
--- a/portfolio/src/components/home/FunctionSidebar.test.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.test.tsx
@@ -23,7 +23,9 @@ test('highlights selected function', () => {
   expect(activeBtn.className).toMatch(/active/);
 });
 
-test('contains profileInfo option', () => {
+test('does not contain profileInfo option after trimming list', () => {
   render(<FunctionSidebar onSelect={() => {}} lang="en" />);
-  expect(screen.getByText('Profile summary and awards')).toBeInTheDocument();
+  expect(
+    screen.queryByText('Profile summary and awards')
+  ).not.toBeInTheDocument();
 });

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -11,6 +11,8 @@ interface FunctionItem {
   id: string;
 }
 
+// The sidebar originally contained a large list of functions which could be
+// overwhelming. Trim the menu to only expose the most commonly used options.
 const functions: FunctionItem[] = [
   { id: 'bioGraph' },
   { id: 'skillTree' },
@@ -18,11 +20,6 @@ const functions: FunctionItem[] = [
   { id: 'personalityRadar' },
   { id: 'contactInfo' },
   { id: 'portfolioSummary' },
-  { id: 'otherSiteLinks' },
-  { id: 'profileInfo' },
-  { id: 'briefIntro' },
-  { id: 'thesisSummary' },
-  { id: 'fusepThesisSummary' },
 ];
 
 export const labels: Record<string, { en: string; ja: string }> = {


### PR DESCRIPTION
## Summary
- shrink the list of functions shown in sidebar to six common options
- update test to confirm `profileInfo` is no longer rendered

## Testing
- `yarn install`
- `yarn test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688b9c5a473c8333be3ef02702c4553e