### PR TITLE
Add dark mode toggle

### DIFF
--- a/portfolio/src/components/header/header.tsx
+++ b/portfolio/src/components/header/header.tsx
@@ -3,6 +3,9 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import LanguageSwitch from '../LanguageSwitch';
+import Switch from '@mui/material/Switch';
+import { useContext } from 'react';
+import { ThemeContext } from '../../context/ThemeContext';
 
 interface HeaderProps {
     lang: 'en' | 'ja';
@@ -10,6 +13,7 @@ interface HeaderProps {
 }
 
 export default function Header(props: HeaderProps){
+    const { theme, toggleTheme } = useContext(ThemeContext);
     return (
         <Box sx={{ flexGrow: 1 }}>
             <AppBar position="static">
@@ -17,6 +21,7 @@ export default function Header(props: HeaderProps){
                     <Typography variant="h6" color="inherit" component="div" sx={{ flexGrow: 1 }}>
                         {props.lang === 'en' ? 'Takanori Kotama' : '樹神 宇徳'}
                     </Typography>
+                    <Switch checked={theme === 'dark'} onChange={toggleTheme} />
                     <LanguageSwitch lang={props.lang} setLang={props.setLang} />
                 </Toolbar>
             </AppBar>

--- a/portfolio/src/components/home/home.css
+++ b/portfolio/src/components/home/home.css
@@ -41,9 +41,9 @@
 .sidebar {
   width: 240px;
   padding: 1rem;
-  background-color: #202123;
-  color: #ececf1;
-  border-right: 1px solid #343541;
+  background-color: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  border-right: 1px solid var(--sidebar-border);
   display: flex;
   flex-direction: column;
 }
@@ -67,26 +67,26 @@
 
 .sidebar-button {
   width: 100%;
-  background: #343541;
+  background: var(--sidebar-button-bg);
   border: none;
   border-radius: 6px;
-  color: #ececf1;
+  color: var(--sidebar-button-text);
   padding: 0.5rem;
   text-align: left;
   cursor: pointer;
 }
 
 .sidebar-button:hover {
-  background: #40414f;
+  background: var(--sidebar-button-hover);
 }
 
 .sidebar-button.active {
-  background: #2b2c2f;
+  background: var(--sidebar-button-active);
 }
 
 .chat-container {
   flex: 1;
-  background: #ffffff;
+  background: var(--chat-bg);
   display: flex;
   height: 100%;
 }
@@ -95,7 +95,7 @@
   align-self: flex-end;
   background: none;
   border: none;
-  color: #ececf1;
+  color: var(--sidebar-text);
   font-size: 1.2rem;
   cursor: pointer;
   margin-bottom: 0.5rem;
@@ -105,10 +105,10 @@
   position: absolute;
   top: 1rem;
   left: 1rem;
-  background: #343541;
+  background: var(--sidebar-open-bg);
   border: none;
   border-radius: 6px;
-  color: #ececf1;
+  color: var(--sidebar-button-text);
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   z-index: 1000;

--- a/portfolio/src/context/ThemeContext.test.tsx
+++ b/portfolio/src/context/ThemeContext.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, ThemeContext } from './ThemeContext';
+import React from 'react';
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+test('toggles and persists theme', () => {
+  render(
+    <ThemeProvider>
+      <ThemeContext.Consumer>
+        {({ theme, toggleTheme }) => (
+          <div>
+            <span data-testid="theme">{theme}</span>
+            <button onClick={toggleTheme}>toggle</button>
+          </div>
+        )}
+      </ThemeContext.Consumer>
+    </ThemeProvider>
+  );
+  expect(screen.getByTestId('theme').textContent).toBe('light');
+  fireEvent.click(screen.getByText('toggle'));
+  expect(screen.getByTestId('theme').textContent).toBe('dark');
+  expect(localStorage.getItem('theme')).toBe('dark');
+});

--- a/portfolio/src/context/ThemeContext.tsx
+++ b/portfolio/src/context/ThemeContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextProps {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextProps>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/portfolio/src/index.css
+++ b/portfolio/src/index.css
@@ -1,3 +1,31 @@
+:root {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --sidebar-bg: #f0f0f0;
+  --sidebar-text: #000000;
+  --sidebar-border: #d0d0d0;
+  --sidebar-button-bg: #ffffff;
+  --sidebar-button-text: #000000;
+  --sidebar-button-hover: #e0e0e0;
+  --sidebar-button-active: #c8c8c8;
+  --chat-bg: #ffffff;
+  --sidebar-open-bg: #ffffff;
+}
+
+[data-theme='dark'] {
+  --background-color: #000000;
+  --text-color: #ffffff;
+  --sidebar-bg: #202123;
+  --sidebar-text: #ececf1;
+  --sidebar-border: #343541;
+  --sidebar-button-bg: #343541;
+  --sidebar-button-text: #ececf1;
+  --sidebar-button-hover: #40414f;
+  --sidebar-button-active: #2b2c2f;
+  --chat-bg: #1e1e1e;
+  --sidebar-open-bg: #343541;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,6 +33,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--background-color);
+  color: var(--text-color);
 }
 
 code {

--- a/portfolio/src/index.tsx
+++ b/portfolio/src/index.tsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from './context/ThemeContext';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- implement `ThemeContext` with persistence
- wrap app in new provider
- switch CSS variables on theme change
- add dark mode toggle in the header
- test context toggling

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688ba14f63c88333a97abb08848c7a26