### PR TITLE
Add simple Firestore timeline component

### DIFF
--- a/portfolio/src/components/timeline/Timeline.test.tsx
+++ b/portfolio/src/components/timeline/Timeline.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { Timestamp } from 'firebase/firestore';
+import Timeline, { TimelineEvent } from './Timeline';
+
+test('renders events in chronological order', () => {
+  const events: TimelineEvent[] = [
+    {
+      title: 'Second',
+      description: 'second event',
+      date: Timestamp.fromDate(new Date('2021-01-02')),
+    },
+    {
+      title: 'First',
+      description: 'first event',
+      date: Timestamp.fromDate(new Date('2021-01-01')),
+    },
+  ];
+
+  render(<Timeline events={events} />);
+
+  const items = screen.getAllByRole('listitem');
+  expect(items[0]).toHaveTextContent('First');
+  expect(items[1]).toHaveTextContent('Second');
+});

--- a/portfolio/src/components/timeline/Timeline.tsx
+++ b/portfolio/src/components/timeline/Timeline.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Timestamp } from 'firebase/firestore';
+import './timeline.css';
+
+export interface TimelineEvent {
+  title: string;
+  description: string;
+  date: Timestamp;
+}
+
+export interface TimelineProps {
+  events: TimelineEvent[];
+}
+
+const Timeline: React.FC<TimelineProps> = ({ events }) => {
+  const sorted = [...events].sort(
+    (a, b) => a.date.toMillis() - b.date.toMillis()
+  );
+
+  return (
+    <ul className="timeline">
+      {sorted.map((event) => (
+        <li key={`${event.title}-${event.date.seconds}`} className="timeline-item">
+          <div className="timeline-date">
+            {event.date.toDate().toLocaleDateString()}
+          </div>
+          <div className="timeline-content">
+            <strong>{event.title}</strong>
+            <p>{event.description}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default Timeline;

--- a/portfolio/src/components/timeline/timeline.css
+++ b/portfolio/src/components/timeline/timeline.css
@@ -1,0 +1,19 @@
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.timeline-item {
+  margin-bottom: 1rem;
+  padding-left: 1rem;
+  border-left: 2px solid #1976d2;
+}
+
+.timeline-date {
+  font-weight: bold;
+}
+
+.timeline-content {
+  margin-left: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add `Timeline` component with simple styling
- include basic tests verifying chronological order

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688ba0ef82108333a51f9077830f5f99