### PR TITLE
Add SkillList component

### DIFF
--- a/portfolio/src/components/skills/SkillList.test.tsx
+++ b/portfolio/src/components/skills/SkillList.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { createSkillList } from './SkillList';
+
+const sample = [
+  { category: 'Programming', skills: ['Python', 'JavaScript'] },
+  { category: 'Tools', skills: ['Docker'] },
+];
+
+test('renders categories and skills', () => {
+  render(<>{createSkillList(sample)}</>);
+  expect(screen.getByRole('heading', { name: 'Programming' })).toBeInTheDocument();
+  expect(screen.getByText('Python')).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Tools' })).toBeInTheDocument();
+  expect(screen.getByText('Docker')).toBeInTheDocument();
+});

--- a/portfolio/src/components/skills/SkillList.tsx
+++ b/portfolio/src/components/skills/SkillList.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export interface SkillCategory {
+  category: string;
+  skills: string[];
+}
+
+export const createSkillList = (data: SkillCategory[]): JSX.Element => {
+  return (
+    <div>
+      {data.map((item) => (
+        <div key={item.category}>
+          <h3>{item.category}</h3>
+          <ul>
+            {item.skills.map((skill) => (
+              <li key={skill}>{skill}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export interface SkillListProps {
+  data: SkillCategory[];
+}
+
+const SkillList: React.FC<SkillListProps> = ({ data }) => {
+  return <>{createSkillList(data)}</>;
+};
+
+export default SkillList;


### PR DESCRIPTION
## Summary
- implement `SkillList` for rendering skill categories and lists
- test that `SkillList` outputs headings and skill entries

## Testing
- `CI=true yarn test --maxWorkers=2 --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ba14592488333a3c04cb3e35761a9