### PR TITLE
Add responsive CSS module for chat UI

### DIFF
--- a/portfolio/src/App.test.tsx
+++ b/portfolio/src/App.test.tsx
@@ -5,6 +5,9 @@ import App from './App';
 jest.mock('react-chatbox-component', () => ({
   ChatBox: () => <div data-testid="chatbox" />,
 }));
+jest.mock('react-chrono', () => ({
+  Chrono: () => <div />,
+}));
 
 beforeAll(() => {
   if (!globalThis.crypto) {

--- a/portfolio/src/components/home/FunctionSidebar.tsx
+++ b/portfolio/src/components/home/FunctionSidebar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styles from './Home.module.css';
 
 export interface FunctionSidebarProps {
   onSelect: (name: string) => void;
@@ -41,23 +42,23 @@ export const labels: Record<string, { en: string; ja: string }> = {
 };
 
 const FunctionSidebar: React.FC<FunctionSidebarProps> = ({ onSelect, selected, onClose, lang }) => (
-  <div className="sidebar">
+  <div className={styles.sidebar}>
     {onClose && (
-      <button className="sidebar-close" onClick={onClose} aria-label="close sidebar">
+      <button className={styles.sidebarClose} onClick={onClose} aria-label="close sidebar">
         ×
       </button>
     )}
     <h3>Sample Chat</h3>
     <ul>
       <li key="newChat">
-        <button className="sidebar-button" onClick={() => onSelect('newChat')}>
+        <button className={styles.sidebarButton} onClick={() => onSelect('newChat')}>
           {labels.newChat[lang]}
         </button>
       </li>
       {functions.map(({ id }) => (
         <li key={id}>
           <button
-            className={`sidebar-button ${selected === id ? 'active' : ''}`}
+            className={`${styles.sidebarButton} ${selected === id ? 'active' : ''}`}
             onClick={() => onSelect(id)}
           >
             {labels[id][lang]}

--- a/portfolio/src/components/home/Home.module.css
+++ b/portfolio/src/components/home/Home.module.css
@@ -1,5 +1,4 @@
-
-.chatbox-wrapper {
+.chatboxWrapper {
   position: relative;
   height: 100%;
   display: flex;
@@ -13,26 +12,24 @@
   overflow-y: auto;
 }
 
-.chatbox-overlay {
+.chatboxOverlay {
   position: absolute;
   inset: 0;
   background: rgba(255, 255, 255, 0.6);
   z-index: 10;
 }
 
-.msg-user {
+.msgUser {
   text-align: right;
   margin: 0.25rem 0;
 }
 
-.msg-bot {
+.msgBot {
   text-align: left;
   margin: 0.25rem 0;
 }
 
-
-
-.home-container {
+.homeContainer {
   display: flex;
   height: calc(100vh - 48px);
   position: relative;
@@ -65,7 +62,7 @@
   margin-bottom: 0.5rem;
 }
 
-.sidebar-button {
+.sidebarButton {
   width: 100%;
   background: #343541;
   border: none;
@@ -76,22 +73,22 @@
   cursor: pointer;
 }
 
-.sidebar-button:hover {
+.sidebarButton:hover {
   background: #40414f;
 }
 
-.sidebar-button.active {
+.sidebarButton.active {
   background: #2b2c2f;
 }
 
-.chat-container {
+.chatContainer {
   flex: 1;
   background: #ffffff;
   display: flex;
   height: 100%;
 }
 
-.sidebar-close {
+.sidebarClose {
   align-self: flex-end;
   background: none;
   border: none;
@@ -101,7 +98,7 @@
   margin-bottom: 0.5rem;
 }
 
-.sidebar-open {
+.sidebarOpen {
   position: absolute;
   top: 1rem;
   left: 1rem;
@@ -114,8 +111,11 @@
   z-index: 1000;
 }
 
+.sidebarOpened {
+}
+
 @media (max-width: 600px) {
-  .home-container {
+  .homeContainer {
     flex-direction: column;
     height: auto;
   }
@@ -132,11 +132,11 @@
     z-index: 1001;
   }
 
-  .sidebar-opened .sidebar {
+  .sidebarOpened .sidebar {
     transform: translateX(0);
   }
 
-  .chat-container {
+  .chatContainer {
     height: calc(100vh - 48px);
   }
 }

--- a/portfolio/src/components/home/home.tsx
+++ b/portfolio/src/components/home/home.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
+import styles from './Home.module.css';
 import { ChatBox } from 'react-chatbox-component';
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAI, getGenerativeModel, GoogleAIBackend } from '@firebase/ai';
 
 import 'react-chatbox-component/dist/style.css';
-import './home.css';
 
 import MessageFormProps from './module/message_form';
 import FirstReply from './module/first_reply';
@@ -136,13 +136,23 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
 
     const [messages, setMessages] = useState<MessageFormProps[]>([])
     const [selectedFunc, setSelectedFunc] = useState<string | null>(null)
-    const [sidebarOpen, setSidebarOpen] = useState<boolean>(true)
+    const [sidebarOpen, setSidebarOpen] = useState<boolean>(
+        typeof window === 'undefined' ? true : window.innerWidth >= 600
+    )
     const [autoFirstReply, setAutoFirstReply] = useState<boolean>(true)
     const [isReplying, setIsReplying] = useState<boolean>(false)
 
     const user = {
         "uid" : "Guest"
     }
+
+    useEffect(() => {
+        const handleResize = () => {
+            setSidebarOpen(window.innerWidth >= 600)
+        }
+        window.addEventListener('resize', handleResize)
+        return () => window.removeEventListener('resize', handleResize)
+    }, [])
 
     const renderMessageBubble = (message: MessageFormProps) => {
         const isUser = user.uid === message.sender.uid;
@@ -346,7 +356,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
     }, [props.lang]);
 
     return (
-        <div className={`home-container${sidebarOpen ? ' sidebar-opened' : ''}`}>
+        <div className={`${styles.homeContainer} ${sidebarOpen ? styles.sidebarOpened : ''}`}> 
             {sidebarOpen ? (
                 <FunctionSidebar
                     onSelect={handleSidebarSelect}
@@ -355,11 +365,11 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
                     lang={props.lang}
                 />
             ) : (
-                <button className='sidebar-open' onClick={() => setSidebarOpen(true)}>Open</button>
+                <button className={styles.sidebarOpen} onClick={() => setSidebarOpen(true)}>☰</button>
             )}
-            <div className='chat-container'>
-                <div className='chatbox-wrapper'>
-                    <div className='chatbox'>
+            <div className={styles.chatContainer}>
+                <div className={styles.chatboxWrapper}>
+                    <div className={styles.chatbox}>
                         <ChatBox
                             messages={messages}
                             user={user}
@@ -367,7 +377,7 @@ export default function Home(props: { lang: 'en' | 'ja' }) {
                             renderMessage={renderMessageBubble}
                         />
                     </div>
-                    {isReplying && <div className='chatbox-overlay'></div>}
+                    {isReplying && <div className={styles.chatboxOverlay}></div>}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- convert home.css to Home.module.css
- wire up new module in Home and FunctionSidebar components
- set sidebar open state based on viewport size
- mock react-chrono in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ba1127ea08333b78d55c61eb92092